### PR TITLE
use tsconfig.json from Vite svelte-ts template

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["svelte.svelte-vscode"]
+}

--- a/blocks/example-file-block/index.svelte
+++ b/blocks/example-file-block/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FileBlockProps } from '@githubnext/blocks';
+  import type { FileBlockProps } from '@githubnext/blocks';
   export let { content } = $$props as FileBlockProps;
 </script>
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@githubnext/blocks": "^2.3.4",
     "@githubnext/blocks-runtime": "^1.0.3",
     "@sveltejs/vite-plugin-svelte": "^2.0.2",
+    "@tsconfig/svelte": "^3.0.0",
     "@vitejs/plugin-basic-ssl": "^1.0.1",
     "esbuild": "^0.16.14",
     "esbuild-plugin-ignore": "^1.1.1",
@@ -19,7 +20,7 @@
     "svelte": "^3.55.0",
     "svelte-preprocess": "^5.0.0",
     "tsup": "^5.6.0",
-    "typescript": "^4.4.4",
+    "typescript": "^4.9.4",
     "vite": "^4.0.4"
   }
 }

--- a/src/BlockComponent.svelte
+++ b/src/BlockComponent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FileContext, FolderContext, Block } from "@githubnext/blocks";
+  import type { FileContext, FolderContext, Block } from "@githubnext/blocks";
 
   export let context: FileContext | FolderContext;
   export let block: Block;

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,4 +1,4 @@
-import { Block, FileContext, FolderContext } from "@githubnext/blocks";
+import type { Block, FileContext, FolderContext } from "@githubnext/blocks";
 import { init } from "@githubnext/blocks-runtime";
 import BlockComponent from "./BlockComponent.svelte";
 
@@ -29,6 +29,7 @@ const loadDevServerBlock = async (block: Block) => {
     if (component) {
       component.$set(fullProps);
     } else {
+      // @ts-ignore
       component = new content.default({ target: root, props: fullProps });
     }
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,20 @@
 {
-  "extends": "./node_modules/@githubnext/blocks/tsconfig.json",
-  "include": ["./blocks", "./src"],
+  "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "types": ["vite/client", "svelte"]
-  }
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "resolveJsonModule": true,
+    /**
+     * Typecheck JS in `.svelte` and `.js` files by default.
+     * Disable checkJs if you'd like to use dynamic types in JS.
+     * Note that setting allowJs false does not prevent the use
+     * of JS in `.svelte` files.
+     */
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedModules": true,
+    "types": ["vite/client"]
+  },
+  "include": ["./blocks", "./src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,6 +696,11 @@
     svelte-hmr "^0.15.1"
     vitefu "^0.2.3"
 
+"@tsconfig/svelte@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@tsconfig/svelte/-/svelte-3.0.0.tgz#b06e059209f04c414de0069f2f0e2796d979fc6f"
+  integrity sha512-pYrtLtOwku/7r1i9AMONsJMVYAtk3hzOfiGNekhtq5tYBGA7unMve8RvUclKLMT3PrihvJqUmzsRGh0RP84hKg==
+
 "@types/hoist-non-react-statics@*":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -2696,10 +2701,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@^4.4.4:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
-  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
+typescript@^4.9.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 unload@2.2.0:
   version "2.2.0"


### PR DESCRIPTION
I've never been very clear on what tsconfig.json settings we should use, and I see that different settings are recommended for different frameworks, so I'm copying the ones from the Vite templates into the Blocks templates.

(and while we're here, copying the recommended VS Code extensions.)